### PR TITLE
feat: stack_trace decorator

### DIFF
--- a/meta.py
+++ b/meta.py
@@ -73,11 +73,11 @@ def adapt(code: str = "", llm: Optional[Callable[[str], str]] = None) -> Callabl
 
 
 """
-The `catch` decorator captures exceptions from the decorated function. An optional Language Learning Model (LLM) 
-function can be passed to generate replacement code in the event of an exception. 
+The `catch` decorator captures exceptions from the decorated function. An optional Language Learning 
+Model (LLM) function can be passed to generate replacement code in the event of an exception. 
 
-If the LLM function is absent or its code also raises an exception, the original exception gets re-raised, allowing 
-for upstream error handling or user notification.
+If the LLM function is absent or its code also raises an exception, the original exception gets re-raised, 
+allowing for upstream error handling or user notification.
 
 Args:
     llm (Callable[[str], str], optional): A function that takes a string of Python code as input and returns a 
@@ -145,16 +145,10 @@ def catch(llm: Optional[Callable[[str], str]] = None) -> Callable:
 
 
 """
-A decorator that catches exceptions thrown by the decorated function, and passes the 
-corresponding stack trace to an optional Language Learning Model (LLM) function.
-
-The LLM function, if provided, is expected to generate a new exception message from the 
-provided stack trace. This message is used to raise a new exception, replacing the original 
-one. This allows for dynamic exception messages based on the context of the error, potentially
-aiding in debugging or providing more descriptive error reports to users.
-
-If the LLM function is not provided, or if it fails to generate a new exception message, 
-the original exception is re-raised.
+A decorator that intercepts exceptions from a decorated function, feeding the stack trace to an 
+optional Language Learning Model (LLM). The LLM, if present, crafts a new exception message from 
+the stack trace, enhancing error reporting or debugging. In the absence of an LLM or if the LLM fails, 
+the original exception is propagated.
 
 Args:
     llm (Callable[[str], str], optional): A function that takes a stack trace as a string 
@@ -178,7 +172,8 @@ def stack_trace(llm: Optional[Callable[[str], str]] = None) -> Callable:
                 # If an LLM function is provided, pass the stack trace to it
                 if llm:
                     prompt = format_stack_trace(stack_trace)
-                    new_exception_message = llm(prompt)
+                    summary = textwrap.dedent(llm(prompt))
+                    new_exception_message = f"{stack_trace}\n{summary}"
 
                     # Raise a new exception with the modified message
                     raise Exception(new_exception_message) from None

--- a/model.py
+++ b/model.py
@@ -7,6 +7,7 @@ import openai
 from dotenv import load_dotenv
 
 load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 """
 OpenAI Completion API wrapper
@@ -20,8 +21,6 @@ Returns:
 
 
 def llm(prompt: str) -> str:
-    openai.api_key = os.getenv("OPENAI_API_KEY")
-
     if openai.api_key is None:
         raise ValueError(
             "The OPENAI_API_KEY environment variable is not set. Please provide your OpenAI API key."

--- a/prompt.py
+++ b/prompt.py
@@ -1,3 +1,5 @@
+import textwrap
+
 """
 Prompt for generating entire functions
 
@@ -10,7 +12,8 @@ Returns:
 
 
 def format_generative_function(code: str) -> str:
-    return f"""
+    return textwrap.dedent(
+        f"""
 	Do not write a driver program, do not comment, do not explain. 
 	Do not write any code outside of the function body.
 	Do not call the function or return a reference to it.
@@ -30,6 +33,7 @@ def format_generative_function(code: str) -> str:
 	Source code:
 	{code}
 	"""
+    )
 
 
 """
@@ -44,8 +48,21 @@ Returns:
 
 
 def format_stack_trace(text: str) -> str:
-    return f"""
-	Summarize the following stack trace and keep and relevant line numbers.
+    return textwrap.dedent(
+        f"""
+	Summarize the following stack trace. Keep relevant line numbers.
+	Given the name of the function where the exception occurred.
+	<function name> is the function name of where the error occurred.
+	<function name> is not the function called wrapper.
+	<function name> is not a file name e.g. ending with .py.
+	Format the stack trace as follows:
+	```
+	Human-readable summary:
+	(<function name>) <exception type>: <exception message>
+	\n
+	```
+
 	Stack trace:
 	{text}
 	"""
+    )

--- a/tests/test_adapt_decorator.py
+++ b/tests/test_adapt_decorator.py
@@ -1,7 +1,7 @@
 # Demo code for dynamic metaprogramming decorator
 import time
 import pytest
-from meta import adapt, catch
+from meta import adapt, catch, stack_trace
 from model import llm
 
 
@@ -93,15 +93,17 @@ def test_stack_trace():
 
     for _ in range(retry_count):
         try:
+
             @stack_trace(llm=llm)
-            def func():
-                raise ValueError("Original exception")
+            def funkodunko():
+                items = [1, 2, 3]
+                return items[5]
 
             try:
-                func()
+                funkodunko()
             except Exception as e:
                 # The exception message should be the stack trace, as returned by the LLM.
-                assert isinstance(e, ValueError)
+                assert isinstance(e, Exception)
                 break
         except Exception as e:
             print(f"Test error: {e}. Retrying after delay...")


### PR DESCRIPTION
1. Refactored prompts out of model.py so meta.py can be extended
2. `stack_trace` decorator for issue #19 
3. Unit test for #19 