### PR TITLE
Fix workflow python versions

### DIFF
--- a/.github/workflows/merged-main.yml
+++ b/.github/workflows/merged-main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout source


### PR DESCRIPTION
fix: quotes around version. mistaking 3.10 as python 3.1