### PR TITLE
Fix python versions matrix

### DIFF
--- a/.github/workflows/merged-main.yml
+++ b/.github/workflows/merged-main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6.7', '3.7.1', '3.8.0', '3.9.0', '3.10.0', '3.11.3']
 
     steps:
     - name: Checkout source


### PR DESCRIPTION
According to the Github action workflow error message:
```
Run actions/setup-python@v2
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

`versions-manifest.json` contains the available cached version of python.

For each version before 3.11, I selected the oldest version and upper bounded test with the latest version of 3.11.3. Each subsequent version bounds the previous version before 3.11.